### PR TITLE
Replaces initiative name with title in table display

### DIFF
--- a/src/views/admin/Initiatives/index.jsx
+++ b/src/views/admin/Initiatives/index.jsx
@@ -80,7 +80,7 @@ const Initiatives = () => {
 				</TableHeaderRow>
 				<TableBody loading={isLoading}>
 					{initiatives?.map(
-						({ _id, name, description, link, createdAt }, index) => {
+						({ _id, title, description, link, createdAt }, index) => {
 							return (
 								<TableDataRow
 									onClick={() => {
@@ -90,7 +90,7 @@ const Initiatives = () => {
 									}}
 									key={index}
 									className="grid grid-cols-4 px-4 py-3 bg-white">
-									<TableData>{name}</TableData>
+									<TableData>{title}</TableData>
 									<TableData>{description}</TableData>
 									<TableData>{link}</TableData>
 									<TableData>


### PR DESCRIPTION
Aligns displayed property with backend changes by using the initiative's title instead of name in the admin table. Prevents potential confusion and ensures consistency with updated data structure.